### PR TITLE
add ILIKE to where constraint

### DIFF
--- a/lib/waterline/utils/query/private/normalize-constraint.js
+++ b/lib/waterline/utils/query/private/normalize-constraint.js
@@ -44,6 +44,7 @@ var MODIFIER_KINDS = {
   'in':         true,
 
   'like':       true,
+  'ilike':       true,
   'contains':   true,
   'startsWith': true,
   'endsWith':   true
@@ -784,7 +785,7 @@ module.exports = function normalizeConstraint (constraintRhs, constraintTarget, 
     //  ╦  ╦╦╔═╔═╗
     //  ║  ║╠╩╗║╣
     //  ╩═╝╩╩ ╩╚═╝
-    else if (modifierKind === 'like') {
+    else if (modifierKind === 'like' || modifierKind === 'ilike') {
 
       // If it matches a known attribute, verify that the attribute
       // does not declare itself `type: 'boolean'` or `type: 'number'`;


### PR DESCRIPTION
As the documentation doesn't mention that "like" is directly supported, might as well directly support "ILIKE" as well. This is minor change, that brings back case-insensitive search functionality (at least to Postgres).  On the mysql side ilike would be something like:

`COLLATE UTF8_GENERAL_CI like '%searchvalue%'`

but that could be done in a separate pull request.